### PR TITLE
Add support for .jscsrc files.

### DIFF
--- a/lib/linter-jscs.js
+++ b/lib/linter-jscs.js
@@ -7,6 +7,7 @@ var extend = require('extendonclass').extendOnClass;
 
 var linterPath = path.join(atom.packages.getLoadedPackage('linter').path, 'lib/linter');
 var Linter = require(linterPath);
+var configFileNames = ['.jscsrc', '.jscs.json'];
 
 // Create `extend` ala BackBone to use the CoffeeScript class
 // within plain and old JavaScript, yeah I prefere JS!
@@ -30,24 +31,28 @@ var JSCSLinter = Linter.extend({
   },
 
   getConf: function () {
+    var homeDir = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
     var projectDir = atom.project.path;
-    var confPath = path.join(projectDir, '.jscs.json');
-    // Is there a `.jscs.json` in the project directory?
-    if (fs.existsSync(confPath)) {
-      return confPath;
-    }
-    else {
-      var homeDir = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
-      confPath = path.join(homeDir, '.jscs.json');
-      // Nevermind let's try in the home directory
+    var confPath, idx;
+    var numConfigFileNames = configFileNames.length;
+
+    // Is there a `.jscs.json` or `.jscsrc` in the project directory?
+    for (idx = 0; idx < numConfigFileNames; idx++) {
+      confPath = path.join(projectDir, configFileNames[idx]);
       if (fs.existsSync(confPath)) {
         return confPath;
       }
-      else {
-        // okey no luck :(
-        return false;
+    }
+    // Nothing found in the project directory, let's look in the home
+    // directory.
+    for (idx = 0; idx < numConfigFileNames; idx++) {
+      confPath = path.join(homeDir, configFileNames[idx]);
+      if (fs.existsSync(confPath)) {
+        return confPath;
       }
     }
+    // okey no luck :(
+    return false;
   }
 });
 


### PR DESCRIPTION
IMO both, .jscs.json and .jscsrc, should be supported in the project
directory _and_ the home directory :)

It seems like the default priority order for the config files changed in jscs about a month ago:
https://github.com/mdevils/node-jscs/commit/e71f2ead526cb298ea15e5892879c84fda6f312b
