### PR TITLE
Fixed .jscsrc file breaking linter-jscs (see #15)

### DIFF
--- a/lib/linter-jscs.coffee
+++ b/lib/linter-jscs.coffee
@@ -47,7 +47,7 @@ class LinterJscs extends Linter
 
   buildCmd: =>
     @cmd = 'jscs -r checkstyle'
-    @cmd = "#{@cmd} -c \"#{@config}\"" if @config
+    @cmd = "#{@cmd} -c #{@config}" if @config
     @cmd = "#{@cmd} -p #{@preset}" if @preset and not @config
 
   destroy: ->


### PR DESCRIPTION
The config file could not be loaded because the config-file was embedded in double-quotes.
See #15 for details.
