### PR TITLE
Add grunt preset

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -9,7 +9,7 @@ module.exports =
     preset:
       type: 'string'
       default: 'airbnb'
-      enum: ['airbnb', 'crockford', 'google', 'jquery', 'mdcs', 'wikimedia', 'yandex']
+      enum: ['airbnb', 'crockford', 'google', 'grunt', 'jquery', 'mdcs', 'wikimedia', 'yandex']
     harmony:
       type: 'boolean'
       default: false


### PR DESCRIPTION
JSCS has added `grunt` preset in november 2014.

See [doc](http://jscs.info/overview.html#presets)