### PR TITLE
Fix config path splitting in order to be OS agnostic.

### DIFF
--- a/lib/linter-jscs.coffee
+++ b/lib/linter-jscs.coffee
@@ -1,3 +1,5 @@
+path = require 'path'
+
 linterPath = atom.packages.getLoadedPackage("linter").path
 Linter = require "#{linterPath}/lib/linter"
 findFile = require "#{linterPath}/lib/util"
@@ -34,7 +36,7 @@ class LinterJscs extends Linter
     @config = findFile @cwd, ['.jscsrc', '.jscs.json', 'package.json']
     # We need to check if the config file is `package.json`
     # it's a specific object on this config file that we need
-    if (@config.split('/')[@config.split('/').length - 1]) is 'package.json'
+    if (@config.split(path.sep)[@config.split(path.sep).length - 1]) is 'package.json'
       # Check that we have an `jscsConfig` object on `package.json`
       # Or we will try to search for `.jscsrc` and `.jscs.json` only
       try


### PR DESCRIPTION
This fix is mainly for Windows where the filesystem uses '\' instead of '/'.

See https://github.com/AtomLinter/linter-jscs/commit/0f7c16ea68cfae22e58f8a7f6f4ca34724b07027