### PR TITLE
Feature: Can select type of lint message 

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -22,6 +22,11 @@ module.exports =
       type: 'boolean'
       default: false
       description: 'Disable linter if there is no config file found for the linter.'
+    messageType:
+      type: 'string'
+      default: 'info'
+      enum: ['info', 'warning', 'error']
+      description: 'Setup type of message (info(blue), warning(yellow), error(red)).'
 
   activate: ->
     console.log 'activate linter-jscs'

--- a/lib/linter-jscs.coffee
+++ b/lib/linter-jscs.coffee
@@ -27,6 +27,9 @@ class LinterJscs extends Linter
   # A string to indicate using jscs config
   config: ''
 
+  # A string to setup type of message (don't understand why default isn't work)
+  defaultLevel: atom.config.get "linter-jscs.messageType" or 'info'
+
   isNodeExecutable: yes
 
   options: ['executablePath', 'preset', 'harmony', 'verbose', 'onlyConfig']

--- a/lib/linter-jscs.coffee
+++ b/lib/linter-jscs.coffee
@@ -28,7 +28,7 @@ class LinterJscs extends Linter
   config: ''
 
   # A string to setup type of message (don't understand why default isn't work)
-  defaultLevel: atom.config.get "linter-jscs.messageType" or 'info'
+  defaultLevel: atom.config.get 'linter-jscs.messageType' or 'info'
 
   isNodeExecutable: yes
 


### PR DESCRIPTION
In my case linter-jscs has most low priority, but it always has error type which has highest priority. I fix it. Now you can chose type of message (priority). 