### PR TITLE
Add description to preset option

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -10,6 +10,7 @@ module.exports =
       type: 'string'
       default: 'airbnb'
       enum: ['airbnb', 'crockford', 'google', 'grunt', 'jquery', 'mdcs', 'wikimedia', 'yandex']
+      description: 'Preset rules are ignored if a config file is found for the linter.'
     harmony:
       type: 'boolean'
       default: false

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -10,7 +10,7 @@ module.exports =
       type: 'string'
       default: 'airbnb'
       enum: ['airbnb', 'crockford', 'google', 'grunt', 'jquery', 'mdcs', 'wikimedia', 'yandex']
-      description: 'Preset rules are ignored if a config file is found for the linter.'
+      description: 'Preset option is ignored if a config file is found for the linter.'
     harmony:
       type: 'boolean'
       default: false


### PR DESCRIPTION
Seems like the relationship between the `preset` option and jscs config files has been confusing to some. I think a short description like this one would help.

Do you know if it is possible to disable input in Atom settings? Maybe it would help more to disable the preset selector if onlyConfig is true...