### PR TITLE
Providing full file path will allow jscs to obey excludeFiles rules

### DIFF
--- a/lib/linter-jscs.coffee
+++ b/lib/linter-jscs.coffee
@@ -73,7 +73,7 @@ class LinterJscs extends Linter
 
   lintFile: (path, next) =>
     condition = (@config and @onlyConfig) or !@onlyConfig
-    path = if condition then path else path: ''
+    path = if condition then @cwd + path.substring(path.lastIndexOf('/')) else path: ''
 
     super path, next
 


### PR DESCRIPTION
Hi!
Have no idea if this is implemented correctly (new to atom), but it satisfies my needs and would close #20 
