### PR TITLE
Fix for `Path is not defined` error

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ export default class LinterJSCS {
 
         const text = editor.getText();
         const errors = this.jscs
-          .checkString(text, path)
+          .checkString(text, filePath)
           .getErrorList();
 
         return errors.map(({ rule, message, line, column }) => {


### PR DESCRIPTION
Fixes #73 

The error points out to `index.js:99:54`, but actually applies to transpiled file in `/Users/[user]/.atom/compile-cache/js/babel/[hashtagPackage]/[hashtagFile.js]` folder which is
```js
          var errors = _this2.jscs.checkString(text, path).getErrorList();
```

To test, remove the `[hashtagPackage]` folder and Atom will transpile source again.