### PR TITLE
Moving JSCS include into the linter function to speed up load time

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use babel';
 
-import JSCS from 'jscs';
 import { Range } from 'atom';
 import { findFile } from 'atom-linter';
 import { readFileSync } from 'fs';
@@ -81,6 +80,8 @@ export default class LinterJSCS {
       scope: 'file',
       lintOnFly: true,
       lint: (editor) => {
+        var JSCS = require('jscs');
+
         // We need re-initialize JSCS before every lint
         // or it will looses the errors, didn't trace the error
         // must be something with new 2.0.0 JSCS

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ export default class LinterJSCS {
       scope: 'file',
       lintOnFly: true,
       lint: (editor) => {
-        var JSCS = require('jscs');
+        const JSCS = require('jscs');
 
         // We need re-initialize JSCS before every lint
         // or it will looses the errors, didn't trace the error


### PR DESCRIPTION
Currently linter-jscs is, _by far_, the slowest loading package in my setup at ~1 sec average load time.  This pushes that load time into the first call of the linter function so that opening instances of the editor that don't need a JS linter aren't affected.