### PR TITLE
Add support for WordPress preset

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ export default class LinterJSCS {
       description: 'Preset option is ignored if a config file is found for the linter.',
       type: 'string',
       default: 'airbnb',
-      enum: ['airbnb', 'crockford', 'google', 'grunt', 'jquery', 'mdcs', 'node-style-guide', 'wikimedia', 'yandex']
+      enum: ['airbnb', 'crockford', 'google', 'grunt', 'jquery', 'mdcs', 'node-style-guide', 'wikimedia', 'wordpress', 'yandex']
     },
     esnext: {
       description: 'Attempts to parse your code as ES6+, JSX, and Flow using the babel-jscs package as the parser.',


### PR DESCRIPTION
This preset is [included with jscs](https://github.com/jscs-dev/node-jscs/tree/v2.1.1/presets); we just need to reference it in `index.js`.

Thanks so much for building linter-jscs! :smile: 