### PR TITLE
Add `configPath` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ export default class LinterJSCS {
         }
 
         // Options passed to `jscs` from package configuration
-        const options = { esnext: this.esnext, preset: this.preset };
+        const options = { configPath: config, esnext: this.esnext, preset: this.preset };
 
         if (config) {
           try {
@@ -124,6 +124,8 @@ export default class LinterJSCS {
                 throw new Error('No `jscsConfig` key in `package.json`');
               }
             }
+
+            parsedConfig.configPath = config;
 
             this.jscs.configure(parsedConfig);
           } catch (error) {


### PR DESCRIPTION
By passing the `configPath` option to JSCS we can add support for `additionalRules` for example:

```json
{
  "additionalRules": ["./test/rules/*.js"]
}
```

Previously, the relative path _"./test/rules*.js"_ would not be resolved since Atom's _CWD_ does not match the project that the user intends to lint.

Also, note that I am passing the full path of the _config_ file because JSCS [calls `dirname` on it](https://github.com/jscs-dev/node-jscs/blob/master/lib/config/node-configuration.js#L201).