### PR TITLE
Save and reset the cursor position after fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,6 +138,8 @@ export default class LinterJSCS {
     const fixedText = this.jscs.fixString(text, path).output;
     if (text === fixedText) return;
 
-    return editor.setText(fixedText);
+    const cursorPosition = editor.getCursorScreenPosition();
+    editor.setText(fixedText);
+    editor.setCursorScreenPosition(cursorPosition);
   }
 };


### PR DESCRIPTION
Currently, when a file is saved and fixed (i.e. the text changes), the cursor position moves to the bottom of the file. This makes an otherwise fantastic plugin virtually unusable.

This will save the cursor position, and move it back after the text is updated, which I've found to make the plugin much more usable.