### PR TITLE
Add a .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf


### PR DESCRIPTION
Force LF line endings from `git`s side to match the .editorconfig.