### PR TITLE
Load jscs config file from an absolute path

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ export default class LinterJSCS {
       enum: ['error', 'warning', 'jscs Warning', 'jscs Error']
     },
     configPath: {
-      title: 'Config file path (Use relative path to your project)',
+      title: 'Config file path (Absolute or relative path to your project)',
       type: 'string',
       default: ''
     }
@@ -152,6 +152,10 @@ export default class LinterJSCS {
   }
 
   static getConfig(filePath) {
+    if (path.isAbsolute(this.configPath)) {
+      return configFile.load(false, this.configPath);
+    }
+
     return configFile.load(false,
       path.join(path.dirname(filePath), this.configPath));
   }


### PR DESCRIPTION
This patch makes it possible to load a jscs config file from an absolute path as well.