### PR TITLE
Work around a jscs bug

### DIFF
--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -134,6 +134,13 @@ export default class LinterJSCS {
         return Promise.resolve(errors.map(({ rule, message, line, column }) => {
           const type = this.displayAs;
           const html = `<span class='badge badge-flexible'>${rule}</span> ${message}`;
+
+          // Work around a bug in jscs causing it to report columns past the end of the line
+          const maxCol = editor.getBuffer().lineLengthForRow(line - 1);
+          if ((column - 1) > maxCol) {
+            column = maxCol + 1;
+          }
+
           const range = helpers.rangeFromLineNumber(editor, line - 1, column - 1);
 
           return { type, html, filePath, range };


### PR DESCRIPTION
In some cases it can report a column past the end of the line.

To be removed when https://github.com/jscs-dev/node-jscs/issues/2083 is fixed.

Fixes #163.