### PR TITLE
Fixed #175

### DIFF
--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -120,7 +120,13 @@ export default class LinterJSCS {
         // Options passed to `jscs` from package configuration
         const options = { esnext: this.esnext, preset: this.preset };
 
-        this.jscs.configure(overrideOptions || Object.assign({}, options, config));
+        // `configPath` is non-enumerable so `Object.assign` won't copy it.
+        // Without a proper `configPath` JSCS plugs cannot be loaded. See #175.
+        let jscsConfig = overrideOptions || Object.assign({}, options, config);
+        if (!jscsConfig.configPath && config) {
+          jscsConfig.configPath = config.configPath;
+        }
+        this.jscs.configure(jscsConfig);
 
         // We don't have a config file present in project directory
         // let's return an empty array of errors


### PR DESCRIPTION
The `configPath` property set on the `config` object by JSCS is done so in a non-enumerable way. So when we use `Object.assign` to merge this package's settings with JSCS config file settings, it is lost in the shuffle. 

This problem is kind of stinky. This solution is a little bit of a hack, but IMHO is acceptable because it's limited to `configPath`. If this problem arises again with another non-enumerable property, that would be a good time to revisit this.