### PR TITLE
Resolve Issue: Support inline <script> #110 

### DIFF
--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -113,6 +113,7 @@ export default class LinterJSCS {
         // must be something with new 2.0.0 JSCS
         this.jscs = new JSCS();
         this.jscs.registerDefaultRules();
+        this.extract = require('jscs/lib/extract-js');
 
         const filePath = editor.getPath();
         const config = this.getConfig(filePath);
@@ -141,7 +142,7 @@ export default class LinterJSCS {
         var errors;
         var result;
         if (editor.getGrammar().scopeName === 'text.html.basic') {
-          result = this.jscs.extractJs(filePath, text);
+          result = this.extract(filePath, text);
 
           result.sources.forEach(function (script) {
             this.jscs.checkString(script.source, filePath).getErrorList().forEach(function (error) {

--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -2,6 +2,7 @@
 
 import path from 'path';
 import configFile from 'jscs/lib/cli-config';
+import extractJs from 'jscs/lib/extract-js';
 import globule from 'globule';
 
 const grammarScopes = ['source.js', 'source.js.jsx', 'text.html.basic'];
@@ -123,7 +124,6 @@ export default class LinterJSCS {
         // must be something with new 2.0.0 JSCS
         this.jscs = new JSCS();
         this.jscs.registerDefaultRules();
-        this.extract = require('jscs/lib/extract-js');
 
         const filePath = editor.getPath();
         const config = this.getConfig(filePath);
@@ -152,7 +152,7 @@ export default class LinterJSCS {
         var errors;
         var result;
         if (this.lintInlineJavaScript && editor.getGrammar().scopeName === 'text.html.basic') {
-          result = this.extract(filePath, text);
+          result = extractJs(filePath, text);
 
           result.sources.forEach(function (script) {
             this.jscs.checkString(script.source, filePath).getErrorList().forEach(function (error) {

--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -21,6 +21,12 @@ export default class LinterJSCS {
       type: 'boolean',
       default: false,
     },
+    lintInlineJavaScript: {
+      title: 'Lint Inline JavaScript',
+      description: 'Lint JavaScript inside `<script>` blocks in HTML files.',
+      type: 'boolean',
+      default: false,
+    },
     onlyConfig: {
       title: 'Only Config',
       description: 'Disable linter if there is no config file found for the linter.',
@@ -52,6 +58,10 @@ export default class LinterJSCS {
 
   static get esnext() {
     return atom.config.get('linter-jscs.esnext');
+  }
+
+  static get lintInlineJavaScript() {
+    return atom.config.get('linter-jscs.lintInlineJavaScript');
   }
 
   static get onlyConfig() {
@@ -141,7 +151,7 @@ export default class LinterJSCS {
 
         var errors;
         var result;
-        if (editor.getGrammar().scopeName === 'text.html.basic') {
+        if (this.lintInlineJavaScript && editor.getGrammar().scopeName === 'text.html.basic') {
           result = this.extract(filePath, text);
 
           result.sources.forEach(function (script) {


### PR DESCRIPTION
This should resolve #110 

* use extractJs from jscs to lint inline `<script>` tags in html files
* added inline linting option to package settings so default behavior is unchanged
* lost `const`ness of errors since it has two code paths, depending on the grammarScope