### PR TITLE
Fix the fix on save being sporadically broken

### DIFF
--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -209,6 +209,31 @@ export default class LinterJSCS {
       return;
     }
 
+    const JSCS = require('jscs');
+
+    // We need re-initialize JSCS before every lint
+    // or it will looses the errors, didn't trace the error
+    // must be something with new 2.0.0 JSCS
+    this.jscs = new JSCS();
+    this.jscs.registerDefaultRules();
+
+    const filePath = editor.getPath();
+
+    // Options passed to `jscs` from package configuration
+    const options = { esnext: this.esnext };
+    if (this.preset !== '<none>') {
+      options.preset = this.preset;
+    }
+
+    // `configPath` is non-enumerable so `Object.assign` won't copy it.
+    // Without a proper `configPath` JSCS plugs cannot be loaded. See #175.
+    let jscsConfig = Object.assign({}, options, config);
+    if (!jscsConfig.configPath && config) {
+      jscsConfig.configPath = config.configPath;
+    }
+
+    this.jscs.configure(jscsConfig);
+
     const fixedText = this.jscs.fixString(editorText, editorPath).output;
     if (editorText === fixedText) {
       return;


### PR DESCRIPTION
Workaround fix for #121
I think the `fixString` function had the same issue as the main linter with losing the errors. Not sure how this works but it works for now for people like me that need the fix on save functionality.

I pulled out the override in the jscsConfig (because I don't know how that's being included too lazy to check), so if someone can help me fix that up. 

Working on particularly crappy code I have to deal with:
![fix-on-save](https://cloud.githubusercontent.com/assets/4655972/13025494/b6d24826-d1d6-11e5-9d7c-ea2fe08cb0bd.gif)


