### PR TITLE
Misc Fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+spec/files/**/*.js
+spec/rules/**/*.js

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,0 @@
-{
-  "preset": "airbnb",
-  "esnext": true
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ os:
   - osx
 
 env:
-  global:
-    - APM_TEST_PACKAGES=""
-
   matrix:
     - ATOM_CHANNEL=stable
     - ATOM_CHANNEL=beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,7 @@ addons:
     - git
     - libgnome-keyring-dev
     - fakeroot
+
+branches:
+  only:
+    - master

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "tdd": "fsmonitor -d src -s -q apm test",
-    "test": "apm test"
+    "test": "apm test",
+    "lint": "eslint ."
   },
   "dependencies": {
     "atom-linter": "^4.3.2",
@@ -30,7 +31,21 @@
     }
   },
   "devDependencies": {
+    "eslint": "^2.4.0",
+    "babel-eslint": "6.0.0-beta.6",
+    "eslint-config-airbnb": "^6.1.0",
     "fsmonitor": "^0.2.4",
     "temp": "^0.8.3"
+  },
+  "eslintConfig": {
+    "extends": "airbnb/base",
+    "parser": "babel-eslint",
+    "globals": {
+      "atom": true
+    },
+    "env": {
+      "es6": true,
+      "node": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/AtomLinter/linter-jscs",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0"
+    "atom": ">=1.0.0 <2.0.0"
   },
   "scripts": {
     "tdd": "fsmonitor -d src -s -q apm test",

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  globals: {
+    waitsForPromise: true
+  },
+  env: {
+    jasmine: true
+  }
+};

--- a/spec/linter-jscs-spec.js
+++ b/spec/linter-jscs-spec.js
@@ -1,10 +1,9 @@
 'use babel';
 
-// var lint = require('../src/linter-jscs');
-
 import linter from '../src/linter-jscs';
 import temp from 'temp';
 import * as path from 'path';
+
 const sloppyPath = path.join(__dirname, 'files', 'sloppy.js');
 const sloppyHTMLPath = path.join(__dirname, 'files', 'sloppy.html');
 const goodPath = path.join(__dirname, 'files', 'good.js');
@@ -57,14 +56,10 @@ describe('The jscs provider for Linter', () => {
         ' Missing comma before closing curly brace';
       waitsForPromise(() =>
         lint(editor).then(messages => {
-          expect(messages[0].type).toBeDefined();
-          expect(messages[0].type).toEqual('error');
-          expect(messages[0].html).toBeDefined();
-          expect(messages[0].html).toEqual(message);
-          expect(messages[0].filePath).toBeDefined();
-          expect(messages[0].filePath).toMatch(/.+sloppy\.js$/);
-          expect(messages[0].range).toBeDefined();
-          expect(messages[0].range.length).toEqual(2);
+          expect(messages[0].type).toBe('error');
+          expect(messages[0].text).not.toBeDefined();
+          expect(messages[0].html).toBe(message);
+          expect(messages[0].filePath).toBe(sloppyPath);
           expect(messages[0].range).toEqual([[2, 11], [2, 12]]);
         })
       );
@@ -75,7 +70,7 @@ describe('The jscs provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(emptyPath).then(editor =>
         lint(editor).then(messages => {
-          expect(messages.length).toEqual(0);
+          expect(messages.length).toBe(0);
         })
       )
     );
@@ -85,7 +80,7 @@ describe('The jscs provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(goodPath).then(editor =>
         lint(editor).then(messages => {
-          expect(messages.length).toEqual(0);
+          expect(messages.length).toBe(0);
         })
       )
     );
@@ -114,14 +109,10 @@ describe('The jscs provider for Linter', () => {
         'Missing comma before closing curly brace';
       waitsForPromise(() =>
         lint(editor).then(messages => {
-          expect(messages[0].type).toBeDefined();
-          expect(messages[0].type).toEqual('error');
-          expect(messages[0].html).toBeDefined();
-          expect(messages[0].html).toEqual(message);
-          expect(messages[0].filePath).toBeDefined();
-          expect(messages[0].filePath).toMatch(/.+sloppy\.html$/);
-          expect(messages[0].range).toBeDefined();
-          expect(messages[0].range.length).toEqual(2);
+          expect(messages[0].type).toBe('error');
+          expect(messages[0].text).not.toBeDefined();
+          expect(messages[0].html).toBe(message);
+          expect(messages[0].filePath).toBe(sloppyHTMLPath);
           expect(messages[0].range).toEqual([[11, 17], [11, 18]]);
         })
       );
@@ -141,7 +132,7 @@ describe('The jscs provider for Linter', () => {
     it('should return no errors if the file is excluded', () => {
       waitsForPromise(() =>
         lint(editor, {}, { excludeFiles: ['sloppy.js'] }).then(messages => {
-          expect(messages.length).toEqual(0);
+          expect(messages.length).toBe(0);
         })
       );
     });
@@ -149,7 +140,7 @@ describe('The jscs provider for Linter', () => {
     it('should return no errors if `requireTrailingComma` is set to null', () => {
       waitsForPromise(() =>
         lint(editor, {}, { requireTrailingComma: null }).then(messages => {
-          expect(messages.length).toEqual(0);
+          expect(messages.length).toBe(0);
         })
       );
     });
@@ -171,7 +162,7 @@ describe('The jscs provider for Linter', () => {
         editor.saveAs(tempFile);
 
         return lint(editor, {}, { }, true).then(messages => {
-          expect(messages.length).toEqual(0);
+          expect(messages.length).toBe(0);
         });
       });
     });
@@ -198,8 +189,8 @@ describe('The jscs provider for Linter', () => {
         'Line must be at most 40 characters';
       waitsForPromise(() =>
         lint(editor, {}, config).then(messages => {
-          expect(messages.length).toEqual(1);
-          expect(messages[0].html).toEqual(message);
+          expect(messages.length).toBe(1);
+          expect(messages[0].html).toBe(message);
         })
       );
     });

--- a/spec/linter-jscs-spec.js
+++ b/spec/linter-jscs-spec.js
@@ -15,150 +15,154 @@ describe('The jscs provider for Linter', () => {
   const lint = linter.provideLinter().lint;
 
   beforeEach(() => {
-    waitsForPromise(() => {
-      return atom.packages.activatePackage('linter-jscs');
-    });
-    waitsForPromise(() => {
-      return atom.packages.activatePackage('language-javascript');
-    });
-    waitsForPromise(() => {
-      return atom.workspace.open(sloppyPath);
-    });
+    waitsForPromise(() =>
+      atom.packages.activatePackage('linter-jscs')
+    );
+    waitsForPromise(() =>
+      atom.packages.activatePackage('language-javascript')
+    );
+    waitsForPromise(() =>
+      atom.workspace.open(sloppyPath)
+    );
   });
 
-  it('should be in the packages list', () => {
-    return expect(atom.packages.isPackageLoaded('linter-jscs')).toBe(true);
-  });
+  it('should be in the packages list', () =>
+    expect(atom.packages.isPackageLoaded('linter-jscs')).toBe(true)
+  );
 
-  it('should be an active package', () => {
-    return expect(atom.packages.isPackageActive('linter-jscs')).toBe(true);
-  });
+  it('should be an active package', () =>
+    expect(atom.packages.isPackageActive('linter-jscs')).toBe(true)
+  );
 
   describe('checks sloppy.js and', () => {
     let editor = null;
     beforeEach(() => {
-      waitsForPromise(() => {
-        return atom.workspace.open(sloppyPath).then(openEditor => {
+      waitsForPromise(() =>
+        atom.workspace.open(sloppyPath).then(openEditor => {
           editor = openEditor;
-        });
-      });
+        })
+      );
     });
 
     it('finds at least one message', () => {
-      waitsForPromise(() => {
-        return lint(editor).then(messages => {
+      waitsForPromise(() =>
+        lint(editor).then(messages => {
           expect(messages.length).toBeGreaterThan(0);
-        });
-      });
+        })
+      );
     });
 
     it('verifies the first message', () => {
-      waitsForPromise(() => {
-        return lint(editor).then(messages => {
+      const message = '<span class=\'badge badge-flexible\'>requireTrailingComma</span>' +
+        ' Missing comma before closing curly brace';
+      waitsForPromise(() =>
+        lint(editor).then(messages => {
           expect(messages[0].type).toBeDefined();
           expect(messages[0].type).toEqual('error');
           expect(messages[0].html).toBeDefined();
-          expect(messages[0].html).toEqual('<span class=\'badge badge-flexible\'>requireTrailingComma</span> Missing comma before closing curly brace');
+          expect(messages[0].html).toEqual(message);
           expect(messages[0].filePath).toBeDefined();
           expect(messages[0].filePath).toMatch(/.+sloppy\.js$/);
           expect(messages[0].range).toBeDefined();
           expect(messages[0].range.length).toEqual(2);
           expect(messages[0].range).toEqual([[2, 11], [2, 12]]);
-        });
-      });
+        })
+      );
     });
   });
 
   it('finds nothing wrong with an empty file', () => {
-    waitsForPromise(() => {
-      return atom.workspace.open(emptyPath).then(editor => {
-        return lint(editor).then(messages => {
+    waitsForPromise(() =>
+      atom.workspace.open(emptyPath).then(editor =>
+        lint(editor).then(messages => {
           expect(messages.length).toEqual(0);
-        });
-      });
-    });
+        })
+      )
+    );
   });
 
   it('finds nothing wrong with a valid file', () => {
-    waitsForPromise(() => {
-      return atom.workspace.open(goodPath).then(editor => {
-        return lint(editor).then(messages => {
+    waitsForPromise(() =>
+      atom.workspace.open(goodPath).then(editor =>
+        lint(editor).then(messages => {
           expect(messages.length).toEqual(0);
-        });
-      });
-    });
+        })
+      )
+    );
   });
 
   describe('checks sloppy.html and', () => {
     let editor = null;
     beforeEach(() => {
-      waitsForPromise(() => {
-        return atom.workspace.open(sloppyHTMLPath).then(openEditor => {
+      waitsForPromise(() =>
+        atom.workspace.open(sloppyHTMLPath).then(openEditor => {
           editor = openEditor;
-        });
-      });
+        })
+      );
     });
 
     it('finds at least one message', () => {
-      waitsForPromise(() => {
-        return lint(editor).then(messages => {
+      waitsForPromise(() =>
+        lint(editor).then(messages => {
           expect(messages.length).toBeGreaterThan(0);
-        });
-      });
+        })
+      );
     });
 
     it('verifies the first message', () => {
-      waitsForPromise(() => {
-        return lint(editor).then(messages => {
+      const message = '<span class=\'badge badge-flexible\'>requireTrailingComma</span> ' +
+        'Missing comma before closing curly brace';
+      waitsForPromise(() =>
+        lint(editor).then(messages => {
           expect(messages[0].type).toBeDefined();
           expect(messages[0].type).toEqual('error');
           expect(messages[0].html).toBeDefined();
-          expect(messages[0].html).toEqual('<span class=\'badge badge-flexible\'>requireTrailingComma</span> Missing comma before closing curly brace');
+          expect(messages[0].html).toEqual(message);
           expect(messages[0].filePath).toBeDefined();
           expect(messages[0].filePath).toMatch(/.+sloppy\.html$/);
           expect(messages[0].range).toBeDefined();
           expect(messages[0].range.length).toEqual(2);
           expect(messages[0].range).toEqual([[11, 17], [11, 18]]);
-        });
-      });
+        })
+      );
     });
   });
 
   describe('provides override options and', () => {
     let editor = null;
     beforeEach(() => {
-      waitsForPromise(() => {
-        return atom.workspace.open(sloppyPath).then(openEditor => {
+      waitsForPromise(() =>
+        atom.workspace.open(sloppyPath).then(openEditor => {
           editor = openEditor;
-        });
-      });
+        })
+      );
     });
 
     it('should return no errors if the file is excluded', () => {
-      waitsForPromise(() => {
-        return lint(editor, {}, { excludeFiles: ['sloppy.js'] }).then(messages => {
+      waitsForPromise(() =>
+        lint(editor, {}, { excludeFiles: ['sloppy.js'] }).then(messages => {
           expect(messages.length).toEqual(0);
-        });
-      });
+        })
+      );
     });
 
     it('should return no errors if `requireTrailingComma` is set to null', () => {
-      waitsForPromise(() => {
-        return lint(editor, {}, { requireTrailingComma: null }).then(messages => {
+      waitsForPromise(() =>
+        lint(editor, {}, { requireTrailingComma: null }).then(messages => {
           expect(messages.length).toEqual(0);
-        });
-      });
+        })
+      );
     });
   });
 
   describe('save', () => {
     let editor = null;
     beforeEach(() => {
-      waitsForPromise(() => {
-        return atom.workspace.open(sloppyPath).then(openEditor => {
+      waitsForPromise(() =>
+        atom.workspace.open(sloppyPath).then(openEditor => {
           editor = openEditor;
-        });
-      });
+        })
+      );
     });
 
     it('should fix the file', () => {
@@ -176,28 +180,28 @@ describe('The jscs provider for Linter', () => {
   describe('custom rules', () => {
     let editor = null;
     beforeEach(() => {
-      waitsForPromise(() => {
-        return atom.workspace.open(lflPath).then(openEditor => {
+      waitsForPromise(() =>
+        atom.workspace.open(lflPath).then(openEditor => {
           editor = openEditor;
-        });
-      });
+        })
+      );
     });
 
     it('should throw error for empty function call', () => {
-      waitsForPromise(() => {
-
-        const config = {
-          additionalRules: [
-            path.join('.', 'spec', 'rules', '*.js'),
-          ],
-          lineLength: 40,
-        };
-
-        return lint(editor, {}, config).then(messages => {
+      const config = {
+        additionalRules: [
+          path.join('.', 'spec', 'rules', '*.js'),
+        ],
+        lineLength: 40,
+      };
+      const message = '<span class=\'badge badge-flexible\'>lineLength</span> ' +
+        'Line must be at most 40 characters';
+      waitsForPromise(() =>
+        lint(editor, {}, config).then(messages => {
           expect(messages.length).toEqual(1);
-          expect(messages[0].html).toEqual('<span class=\'badge badge-flexible\'>lineLength</span> Line must be at most 40 characters');
-        });
-      });
+          expect(messages[0].html).toEqual(message);
+        })
+      );
     });
   });
 });

--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -77,7 +77,7 @@ export default class LinterJSCS {
 
   static activate() {
     // Install dependencies using atom-package-deps
-    require('atom-package-deps').install();
+    require('atom-package-deps').install('linter-jscs');
 
     this.observer = atom.workspace.observeTextEditors((editor) => {
       editor.getBuffer().onWillSave(() => {

--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -5,6 +5,7 @@ import configFile from 'jscs/lib/cli-config';
 import extractJs from 'jscs/lib/extract-js';
 import globule from 'globule';
 import objectAssign from 'object-assign';
+import { CompositeDisposable } from 'atom';
 
 const grammarScopes = ['source.js', 'source.js.jsx', 'text.html.basic'];
 
@@ -51,35 +52,37 @@ export default class LinterJSCS {
     },
   };
 
-  static get preset() {
-    return atom.config.get('linter-jscs.preset');
-  }
-
-  static get esnext() {
-    return atom.config.get('linter-jscs.esnext');
-  }
-
-  static get onlyConfig() {
-    return atom.config.get('linter-jscs.onlyConfig');
-  }
-
-  static get fixOnSave() {
-    return atom.config.get('linter-jscs.fixOnSave');
-  }
-
-  static get displayAs() {
-    return atom.config.get('linter-jscs.displayAs');
-  }
-
-  static get configPath() {
-    return atom.config.get('linter-jscs.configPath');
-  }
-
   static activate() {
     // Install dependencies using atom-package-deps
     require('atom-package-deps').install('linter-jscs');
 
-    this.observer = atom.workspace.observeTextEditors((editor) => {
+    this.subscriptions = new CompositeDisposable;
+
+    this.subscriptions.add(atom.config.observe('linter-jscs.preset', (preset) => {
+      this.preset = preset;
+    }));
+
+    this.subscriptions.add(atom.config.observe('linter-jscs.esnext', (esnext) => {
+      this.esnext = esnext;
+    }));
+
+    this.subscriptions.add(atom.config.observe('linter-jscs.onlyConfig', (onlyConfig) => {
+      this.onlyConfig = onlyConfig;
+    }));
+
+    this.subscriptions.add(atom.config.observe('linter-jscs.fixOnSave', (fixOnSave) => {
+      this.fixOnSave = fixOnSave;
+    }));
+
+    this.subscriptions.add(atom.config.observe('linter-jscs.displayAs', (displayAs) => {
+      this.displayAs = displayAs;
+    }));
+
+    this.subscriptions.add(atom.config.observe('linter-jscs.configPath', (configPath) => {
+      this.configPath = configPath;
+    }));
+
+    this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
       editor.getBuffer().onWillSave(() => {
         if (grammarScopes.indexOf(editor.getGrammar().scopeName) !== -1 || this.testFixOnSave) {
           // Exclude `excludeFiles` for fix on save
@@ -93,11 +96,11 @@ export default class LinterJSCS {
           }
         }
       });
-    });
+    }));
   }
 
   static deactivate() {
-    this.observer.dispose();
+    this.subscriptions.dispose();
   }
 
   static provideLinter() {

--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -230,11 +230,8 @@ export default class LinterJSCS {
 
     // Options passed to `jscs` from package configuration
     const options = { esnext: this.esnext };
-    if (this.preset !== '<none>') {
-      options.preset = this.preset;
-    }
 
-    const jscsConfig = Object.assign({}, options, config);
+    const jscsConfig = Object.assign({}, options, config || { preset: this.preset });
     // `configPath` is non-enumerable so `Object.assign` won't copy it.
     // Without a proper `configPath` JSCS plugs cannot be loaded. See #175.
     if (!jscsConfig.configPath && config) {

--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -43,7 +43,7 @@ export default class LinterJSCS {
       title: 'Display errors as',
       type: 'string',
       default: 'error',
-      enum: ['error', 'warning', 'jscs Warning', 'jscs Error'],
+      enum: ['error', 'warning'],
     },
     configPath: {
       title: 'Config file path (Absolute or relative path to your project)',


### PR DESCRIPTION
This PR:

* Configures `eslint` to lint this package. Previously `jscs` was "linting" this package, but it was only ever intended to be a style guide, not something that detects issues with the code itself. `eslint` handles the style part more completely anyway so there is absolutely no reason to use `jscs`.
* Specify a maximum Atom version
* Minor cleanup to Travis-CI config
* `observe()` the settings instead of `get()`ing them on every access
* Remove the `jscs error` and `jscs warning` types as specifying the package name for current linter versions makes that redundant
* Bring the configuration gathering functionality together in one place, meaning linting and fixing use the same config. Fixes #197.