### PR TITLE
Move to eslint-config-airbnb-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "atom-linter": "^4.6.1",
+    "atom-linter": "^4.7.0",
     "atom-package-deps": "^4.0.1",
     "globule": "^1.0.0",
     "jscs": "2.11.0",
@@ -31,16 +31,20 @@
     }
   },
   "devDependencies": {
-    "eslint": "^2.7.0",
+    "eslint": "^2.8.0",
     "babel-eslint": "^6.0.2",
-    "eslint-config-airbnb": "^7.0.0",
-    "eslint-plugin-react": "^4.3.0",
+    "eslint-config-airbnb-base": "^1.0.3",
+    "eslint-plugin-import": "^1.5.0",
     "fsmonitor": "^0.2.4",
     "temp": "^0.8.3"
   },
   "eslintConfig": {
-    "extends": "airbnb/base",
+    "extends": "airbnb-base",
     "parser": "babel-eslint",
+    "rules": {
+      "global-require": 0,
+      "import/no-unresolved": [2, { "ignore": ["atom"] }]
+    },
     "globals": {
       "atom": true
     },

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  globals: {
-    waitsForPromise: true
-  },
   env: {
-    jasmine: true
+    jasmine: true,
+    atomtest: true,
   }
 };


### PR DESCRIPTION
We have no need of the React components of eslint-config-airbnb, so move to the base package.

Closes #226.
Closes #227.