### PR TITLE
Add some performance metrics and some early-exit optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
     "extends": "airbnb-base",
     "parser": "babel-eslint",
     "rules": {
-      "global-require": 0,
+      "no-console": ["off"],
+      "global-require": ["off"],
       "import/no-unresolved": [
-        2,
+        "error",
         {
           "ignore": [
             "atom"


### PR DESCRIPTION
If Atom is in dev mode performance metrics of how long the total lint took, as well as how lpong JSCS itself took are output to the console. Also fixes some early-exit scenarios such as when a file was ignored by the configuration. Previously JSCS was fully initialized before checking if the file was ignored.