### PR TITLE
Don't fix HTML on save

### DIFF
--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -91,7 +91,10 @@ export default class LinterJSCS {
 
     this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
       editor.getBuffer().onWillSave(() => {
-        if (grammarScopes.indexOf(editor.getGrammar().scopeName) !== -1 || this.testFixOnSave) {
+        const scope = editor.getGrammar().scopeName;
+        if ((grammarScopes.indexOf(scope) !== -1 && scope !== 'text.html.basic')
+          || this.testFixOnSave
+        ) {
           // Exclude `excludeFiles` for fix on save
           const config = this.getConfig(editor.getPath());
           const exclude = globule.isMatch(


### PR DESCRIPTION
This should block running the fix routine on HTML files, as it relies on an external utility to even work in the first place.

Fixes #203.