### PR TITLE
Remove the yandex preset

### DIFF
--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -35,7 +35,7 @@ export default class LinterJSCS {
       default: 'airbnb',
       enum: [
         'airbnb', 'crockford', 'google', 'grunt', 'idiomatic', 'jquery', 'mdcs',
-        'node-style-guide', 'wikimedia', 'wordpress', 'yandex',
+        'node-style-guide', 'wikimedia', 'wordpress',
       ],
     },
     onlyConfig: {


### PR DESCRIPTION
This preset was removed from JSCS in the v3 update.

Fixes #252.