### PR TITLE
Activate linter-jscs only when needed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,13 @@
       }
     }
   },
+  "activationHooks": [
+    "language-babel:grammar-used",
+    "language-html:grammar-used",
+    "language-javascript-jsx:grammar-used",
+    "language-javascript:grammar-used",
+    "language-jsx:grammar-used"
+  ],
   "devDependencies": {
     "eslint": "^2.9.0",
     "babel-eslint": "^6.0.2",

--- a/spec/linter-jscs-spec.js
+++ b/spec/linter-jscs-spec.js
@@ -14,15 +14,17 @@ describe('The jscs provider for Linter', () => {
   const lint = linter.provideLinter().lint;
 
   beforeEach(() => {
-    waitsForPromise(() =>
-      atom.packages.activatePackage('linter-jscs')
-    );
+    const activationPromise = atom.packages.activatePackage('linter-jscs');
+
     waitsForPromise(() =>
       atom.packages.activatePackage('language-javascript')
     );
     waitsForPromise(() =>
       atom.workspace.open(sloppyPath)
     );
+
+    atom.packages.triggerDeferredActivationHooks();
+    waitsForPromise(() => activationPromise);
   });
 
   it('should be in the packages list', () =>


### PR DESCRIPTION
Activation is delayed until an editor with a supported grammar is opened.
This will avoid performance penalties (see #294) when working on projects
that do not contain JS at all.