### PR TITLE
Update CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,43 @@
+
+# Project specific config
+
+# Installed for linting the project
+language: node_js
+
+matrix:
+  include:
+    - os: linux
+      node_js: "6"
+      env: ATOM_CHANNEL=stable
+
+    - os: linux
+      node_js: "6"
+      env: ATOM_CHANNEL=beta
+
+    - os: osx
+      node_js: "6"
+      env: ATOM_CHANNEL=stable
+
+env:
+  global:
+    - APM_TEST_PACKAGES=""
+
+# Generic setup follows
+script: 'curl -Ls https://github.com/Arcanemagus/ci/raw/atomlinter/build-package.sh | sh'
+
 notifications:
   email:
     on_success: never
     on_failure: change
 
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+branches:
+  only:
+    - master
 
 git:
   depth: 10
 
 sudo: false
-
-os:
-  - linux
-  - osx
-
-env:
-  matrix:
-    - ATOM_CHANNEL=stable
-    - ATOM_CHANNEL=beta
 
 addons:
   apt:
@@ -26,7 +46,3 @@ addons:
     - git
     - libgnome-keyring-dev
     - fakeroot
-
-branches:
-  only:
-    - master

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "language-jsx:grammar-used"
   ],
   "devDependencies": {
-    "eslint": "^2.9.0",
     "babel-eslint": "^6.0.2",
+    "eslint": "^2.9.0",
     "eslint-config-airbnb-base": "^3.0.0",
     "eslint-plugin-import": "^1.7.0",
     "fsmonitor": "^0.2.4",
@@ -49,12 +49,8 @@
     "extends": "airbnb-base",
     "parser": "babel-eslint",
     "rules": {
-      "no-console": [
-        "off"
-      ],
-      "global-require": [
-        "off"
-      ],
+      "no-console": "off",
+      "global-require": "off",
       "import/no-unresolved": [
         "error",
         {

--- a/spec/linter-jscs-spec.js
+++ b/spec/linter-jscs-spec.js
@@ -160,7 +160,7 @@ describe('The jscs provider for Linter', () => {
 
     it('should fix the file', () => {
       waitsForPromise(() => {
-        const tempFile = temp.openSync().path;
+        const tempFile = temp.track().openSync().path;
         editor.saveAs(tempFile);
 
         return lint(editor, {}, { }, true).then(messages => {


### PR DESCRIPTION
Ensure's Node.js v6 is installed on the system, and moves to a script that uses the system Node.js for linting. This should be switched back to the atom/ci scripts when a stable Atom release includes an `apm` with a usable `node` version.