### PR TITLE
Remove babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "language-jsx:grammar-used"
   ],
   "devDependencies": {
-    "babel-eslint": "^6.0.2",
     "eslint": "^3.6.1",
     "eslint-config-airbnb-base": "^8.0.0",
     "eslint-plugin-import": "^1.16.0",
@@ -47,7 +46,6 @@
   },
   "eslintConfig": {
     "extends": "airbnb-base",
-    "parser": "babel-eslint",
     "rules": {
       "no-console": "off",
       "global-require": "off",


### PR DESCRIPTION
There is no longer a need for this parser. This cleans the code up a bit and removes the dependency on it.

Closes #308.