### PR TITLE
Update to eslint-config-airbnb-base v11.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "devDependencies": {
     "eslint": "^3.12.0",
-    "eslint-config-airbnb-base": "^11.0.0",
+    "eslint-config-airbnb-base": "^11.1.0",
     "eslint-plugin-import": "^2.2.0",
     "fsmonitor": "^0.2.4",
     "temp": "^0.8.3"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "language-jsx:grammar-used"
   ],
   "devDependencies": {
-    "eslint": "^3.12.0",
+    "eslint": "^3.15.0",
     "eslint-config-airbnb-base": "^11.1.0",
     "eslint-plugin-import": "^2.2.0",
     "fsmonitor": "^0.2.4",


### PR DESCRIPTION
This version includes a newer minimum ESLint version, requiring that be specified.