### PR TITLE
Upgrade to linter API v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "object-assign": "^4.0.1"
   },
   "package-deps": [
-    "linter"
+    "linter:2.0.0"
   ],
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },

--- a/spec/linter-jscs-spec.js
+++ b/spec/linter-jscs-spec.js
@@ -36,15 +36,15 @@ describe('The jscs provider for Linter', () => {
   it('checks sloppy.js and verifies the first message', async () => {
     const editor = await atom.workspace.open(sloppyPath);
     const messages = await lint(editor);
-    const message = '<span class=\'badge badge-flexible\'>requireTrailingComma</span>'
-      + ' Missing comma before closing curly brace';
+    const message = 'requireTrailingComma: '
+      + 'Missing comma before closing curly brace';
 
     expect(messages.length).toBe(2);
-    expect(messages[0].type).toBe('error');
-    expect(messages[0].text).not.toBeDefined();
-    expect(messages[0].html).toBe(message);
-    expect(messages[0].filePath).toBe(sloppyPath);
-    expect(messages[0].range).toEqual([[2, 9], [2, 11]]);
+    expect(messages[0].severity).toBe('error');
+    expect(messages[0].description).not.toBeDefined();
+    expect(messages[0].excerpt).toBe(message);
+    expect(messages[0].location.file).toBe(sloppyPath);
+    expect(messages[0].location.position).toEqual([[2, 9], [2, 11]]);
   });
 
   it('finds nothing wrong with an empty file', async () => {
@@ -64,15 +64,15 @@ describe('The jscs provider for Linter', () => {
   it('checks sloppy.html and verifies the first message', async () => {
     const editor = await atom.workspace.open(sloppyHTMLPath);
     const messages = await lint(editor);
-    const message = '<span class=\'badge badge-flexible\'>requireTrailingComma</span> '
+    const message = 'requireTrailingComma: '
       + 'Missing comma before closing curly brace';
 
     expect(messages.length).toBe(2);
-    expect(messages[0].type).toBe('error');
-    expect(messages[0].text).not.toBeDefined();
-    expect(messages[0].html).toBe(message);
-    expect(messages[0].filePath).toBe(sloppyHTMLPath);
-    expect(messages[0].range).toEqual([[11, 15], [11, 17]]);
+    expect(messages[0].severity).toBe('error');
+    expect(messages[0].description).not.toBeDefined();
+    expect(messages[0].excerpt).toBe(message);
+    expect(messages[0].location.file).toBe(sloppyHTMLPath);
+    expect(messages[0].location.position).toEqual([[11, 15], [11, 17]]);
   });
 
   describe('provides override options and', () => {

--- a/src/linter-jscs.js
+++ b/src/linter-jscs.js
@@ -232,7 +232,7 @@ export default {
       name: 'JSCS',
       grammarScopes,
       scope: 'file',
-      lintOnFly: true,
+      lintsOnChange: true,
       lint: (editor, opts, overrideOptions, testFixOnSave) => {
         startMeasure('linter-jscs: Lint');
 
@@ -300,18 +300,15 @@ export default {
         endMeasure('linter-jscs: JSCS');
 
         const translatedErrors = errors.map(({
-          rule, message, line, column,
-        }) => {
-          const type = displayAs;
-          // TODO: Remove this when https://github.com/jscs-dev/node-jscs/issues/2235 has been addressed
-          const cleanMessage = message.replace(`${rule}: `, '');
-          const html = `<span class='badge badge-flexible'>${rule}</span> ${cleanMessage}`;
-          const range = helpers.generateRange(editor, line - 1, column - 1);
-
-          return {
-            type, html, filePath, range,
-          };
-        });
+          message, line, column,
+        }) => ({
+          severity: displayAs,
+          excerpt: message,
+          location: {
+            file: filePath,
+            position: helpers.generateRange(editor, line - 1, column - 1),
+          },
+        }));
         endMeasure('linter-jscs: Lint');
         return Promise.resolve(translatedErrors);
       },


### PR DESCRIPTION
Upgrade this provider to the v2 linter API so it can continue to work with newer versions of `linter`.

Fixes #361.